### PR TITLE
fix: catppuccin and oxocarbon are flipped

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,8 +31,8 @@
       wallpkgs = callWallpaper null;
 
       # Call individual collections by category.
-      oxocarbon = callWallpaper "catppuccin";
-      catppuccin = callWallpaper "oxocarbon";
+      catppuccin = callWallpaper "catppuccin";
+      oxocarbon = callWallpaper "oxocarbon";
       cities = callWallpaper "cities";
       monochrome = callWallpaper "monochrome";
       nature = callWallpaper "nature";


### PR DESCRIPTION
i noticed while building the oxocarbon package that i had the catppuccin wallpapers and i realised that catppuccin and oxocarbon are in the wrong order, i'll be frank i should have caught onto that during the oxocarbon PR i made lmao.

this pr fixes that discrepency, sorry for any confusion.