### PR TITLE
meta: stop wallpaper contributions for the time being

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!IMPORTANT]
+> We do **not** want to accept new wallpapers for the time being as the flake
+> is now eating up __800MB__ of space in the /nix/store per new commit. We
+> will start accepting new wallpapers again once we are able to debloat this
+> repository.
+
 # Wallpkgs
 
 Somewhat curated collection of various wallpapers that I have came across, or


### PR DESCRIPTION
## Does this break anything?

No.

## What does this add/change/remove?

This adds a warning at the top of the repo to ward new contributors
since we would prefer to drop the size of the repo to something
more acceptable before wanting new wallpapers.

## Will I add anymore changes?

Not on this branch.